### PR TITLE
Publish API Docs to GH Pages when merging to master

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -40,3 +40,30 @@ jobs:
 
       # can access mongo on localhost
       - run: sleep 5 && nc -vz localhost 27017
+
+  deploy-gh-pages:
+    docker:
+      - image: circleci/node:latest
+
+    working_directory: ~/repo
+
+    steps:
+      - checkout
+      # Generate API DOC
+      - run: yarn add apidoc
+      - run: node_modules/apidoc/bin/apidoc -f "./routes/.*\\.js$" -i ./  -o ./public/apidoc/
+      # Publish API DOC in Github Pages
+      - run: ./scripts/deploy-ghpages.sh ./public/apidoc
+
+workflows:
+  version: 2
+  build-deploy:
+    jobs:
+      - build:
+          filters:
+            branches:
+              ignore: develop
+      - deploy-gh-pages:
+          filters:
+            branches:
+              only: develop

--- a/scripts/deploy-ghpages.sh
+++ b/scripts/deploy-ghpages.sh
@@ -1,0 +1,55 @@
+#!/bin/sh
+# ideas used from https://gist.github.com/motemen/8595451
+
+# abort the script if there is a non-zero error
+set -e
+
+# show where we are on the machine
+pwd
+
+remote=$(git config remote.origin.url)
+
+siteSource="$1"
+
+if [ ! -d "$siteSource" ]
+then
+    echo "Usage: $0 <site source dir>"
+    exit 1
+fi
+
+# make a directory to put the gp-pages branch
+mkdir gh-pages-branch
+cd gh-pages-branch
+# now lets setup a new repo so we can update the gh-pages branch
+git config --global user.email "$GH_EMAIL" > /dev/null 2>&1
+git config --global user.name "$GH_NAME" > /dev/null 2>&1
+git init
+git remote add --fetch origin "$remote"
+
+# switch into the gh-pages branch
+if git rev-parse --verify origin/gh-pages > /dev/null 2>&1
+then
+    git checkout gh-pages
+    # delete any old site as we are going to replace it
+    # Note: this explodes if there aren't any, so moving it here for now
+    git rm -rf .
+else
+    git checkout --orphan gh-pages
+fi
+
+# copy over or recompile the new site
+cp -a "../${siteSource}/." .
+
+# stage any changes and new files
+git add -A
+# now commit, ignoring branch gh-pages doesn't seem to work, so trying skip
+git commit --allow-empty -m "Deploy to GitHub pages [ci skip]"
+# and push, but send any output to /dev/null to hide anything sensitive
+git push --force --quiet origin gh-pages > /dev/null 2>&1
+
+# go back to where we started and remove the gh-pages git repo we made and used
+# for deployment
+cd ..
+rm -rf gh-pages-branch
+
+echo "Finished Deployment!"


### PR DESCRIPTION
## Summary
This circleci config will ensure that:
- Tests run for every commit made in a branch that is not `develop`
- API Docs are generated and published as a GH Page when a branch is merged to `develop`

## Required steps before merging:
1. Create a clean `gh-pages` branch following these steps:
2. Follow the steps on [deployment-circleci-gh-pages ](https://github.com/Villanuevand/deployment-circleci-gh-pages) skipping the `circle.yml` and `deploy.sh` configuration
 
Solves: https://github.com/kleros/kleros-store/issues/16