### PR TITLE
fix: use non-checksum arbitrator address

### DIFF
--- a/controllers/arbitrators.js
+++ b/controllers/arbitrators.js
@@ -1,7 +1,7 @@
 const Arbitrator = require('../models/Arbitrators')
 
 exports.updateArbitrator = async (req, res) => {
-  const arbitratorAddress = req.params.arbitratorAddress
+  const arbitratorAddress = req.params.arbitratorAddress.toLowerCase()
   const body = req.body
 
   const newArbitratorInstance = new Arbitrator(
@@ -23,7 +23,7 @@ exports.updateArbitrator = async (req, res) => {
 }
 
 exports.getArbitrator = async (req, res) => {
-  const arbitratorAddress = req.params.arbitratorAddress
+  const arbitratorAddress = req.params.arbitratorAddress.toLowerCase()
 
   const arbitrator = await getArbitratorDb(arbitratorAddress)
   return res.json(arbitrator)

--- a/controllers/dispute.js
+++ b/controllers/dispute.js
@@ -4,7 +4,7 @@ const Dispute = require('../models/Disputes'),
 
 exports.updateDisputeProfile = async (req, res) => {
   const disputeId = req.params.disputeId
-  const arbitratorAddress = req.params.arbitratorAddress
+  const arbitratorAddress = req.params.arbitratorAddress.toLowerCase()
   const bodyContract = req.body
 
   const dispute = await getDisputeDb(arbitratorAddress, disputeId)
@@ -18,7 +18,7 @@ exports.updateDisputeProfile = async (req, res) => {
 
 exports.getDispute = async (req, res) => {
   const disputeId = req.params.disputeId
-  const arbitratorAddress = req.params.arbitratorAddress
+  const arbitratorAddress = req.params.arbitratorAddress.toLowerCase()
 
   const dispute = await getDisputeDb(arbitratorAddress, disputeId)
   return res.json(dispute)

--- a/controllers/profile.js
+++ b/controllers/profile.js
@@ -114,7 +114,7 @@ exports.addEvidenceContractProfile = async (req, res) => {
 exports.updateDisputesProfile = async (req, res) => {
   const address = req.params.address
   const disputeId = parseInt(req.params.disputeId)
-  const arbitratorAddress = req.params.arbitratorAddress
+  const arbitratorAddress = req.params.arbitratorAddress.toLowerCase()
 
   const ProfileInstance = await getProfileDb(address)
 


### PR DESCRIPTION
Should be able to fetch data no matter if checksum address is used or not. Always store and fetch as non-checksum address